### PR TITLE
Scrum 234 optimisasi forum vote

### DIFF
--- a/forum/api.py
+++ b/forum/api.py
@@ -150,7 +150,7 @@ def update_forum(request, forum_id: UUID, data: ForumUpdateSchema):
     if request.user != forum.user:
         return Response({"error": "You are not authorized to update this forum post."}, status=403)
 
-    updated_forum = ForumRepository.update_forum(
+    updated_forum = ForumRepository.update_forum_by_id(
         forum_id,
         title=data.title,
         description=data.description
@@ -175,7 +175,7 @@ def vote_summary(request, forum_id: UUID):
     summary = ForumRepository.get_vote_summary(forum)
     
     user_vote = ForumVote.objects.filter(user=request.user, forum=forum).first()
-    summary["user_vote"] = user_vote.vote_choice if user_vote else None
+    summary["user_vote"] = "up" if user_vote else None
 
     return summary
 
@@ -184,12 +184,12 @@ def update_forum(request, forum_id: UUID, data: ForumUpdateSchema):
     try:
         forum = ForumRepository.get_forum_by_id(forum_id)
 
-        if forum.user != request.user:
-            return Response({"error": "You are not authorized to update this forum."}, status=403)
+        if forum.user != request.user: return Response({"error": "You are not authorized to update this forum."}, status=403)
 
         updated_forum = ForumRepository.update_forum_by_id(forum_id, data.title, data.description)
         return updated_forum
-    except Http404:
-        return Response({"error": "Forum not found."}, status=404)
-    except Exception as e:
-        return Response({"error": str(e)}, status=500)
+        
+    except Http404: return Response({"error": "Forum not found."}, status=404)
+    except Exception as e: return Response({"error": str(e)}, status=500)
+
+

--- a/forum/api.py
+++ b/forum/api.py
@@ -2,7 +2,6 @@ from typing import List
 from ninja import Router, Query
 from ninja.responses import Response
 from uuid import UUID
-from django.contrib.auth.models import User
 from forum.models import ForumVote
 from forum.schemas import ForumUpdateSchema, ForumOutputSchema, ForumCreateSchema, ForumReplySchema
 from forum.repositories.forum_repository import ForumRepository
@@ -90,6 +89,36 @@ def get_forums_by_user(request):
     forums = ForumRepository.get_forums_by_user(request.user)
     return forums
 
+@router.get("/forum_overview", response=List[ForumOutputSchema], auth=JWTAuth())
+def forum_overview(request, limit: int = Query(20, ge=1, le=100), offset: int = Query(0, ge=0)):
+    forums = ForumRepository.list_forums(limit=limit, offset=offset, parent_id=None)
+    forum_ids = [forum.id for forum in forums]
+
+    vote_summaries = ForumRepository.get_vote_summary(forum_ids)
+    user_votes = ForumVote.objects.filter(user=request.user, forum_id__in=forum_ids).values_list("forum_id", flat=True)
+
+    result = []
+    for forum in forums:
+        result.append({
+            "id": forum.id,
+            "user": {
+                "id": forum.user.id,
+                "username": forum.user.username, 
+                "first_name": forum.user.first_name,
+                "last_name": forum.user.last_name,
+            },
+            "title": forum.title,
+            "description": forum.description,
+            "tag": forum.tag,
+            "timestamp": forum.timestamp,
+            "parent_id": forum.parent.id if forum.parent else None,
+            "replies": [],
+            "upvotes": vote_summaries.get(forum.id, {}).get("upvotes", 0),
+            "user_vote": "up" if forum.id in user_votes else None,
+        })
+
+    return result
+
 from silk.profiling.profiler import silk_profile
 @silk_profile(name="Profiling Search Forum")
 @router.get("/search", response=List[ForumOutputSchema], auth=JWTAuth())
@@ -172,7 +201,9 @@ def cancel_vote(request, forum_id: UUID):
 @router.get("/vote_summary/{forum_id}", auth=JWTAuth())
 def vote_summary(request, forum_id: UUID):
     forum = ForumRepository.get_forum_by_id(forum_id)
-    summary = ForumRepository.get_vote_summary(forum)
+    summary = ForumRepository.get_vote_summary([forum.id])
+
+    summary = summary.get(forum.id, {"upvotes": 0})
     
     user_vote = ForumVote.objects.filter(user=request.user, forum=forum).first()
     summary["user_vote"] = "up" if user_vote else None

--- a/forum/repositories/forum_repository.py
+++ b/forum/repositories/forum_repository.py
@@ -7,8 +7,6 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 
-
-
 class ForumRepository:
     @staticmethod
     def get_forum_by_id(forum_id: UUID) -> Forum:
@@ -38,9 +36,17 @@ class ForumRepository:
         forum.delete()
 
     @staticmethod
-    def list_forums(limit=20, offset=0):
-        return Forum.objects.select_related("user") \
-            .order_by("-timestamp")[offset:offset + limit]
+    def list_forums(limit=20, offset=0, parent_id: Optional[UUID] = None):
+        """
+        Mengambil daftar forum dengan pagination dan filter parent_id.
+        Jika parent_id=None, hanya forum utama yang diambil.
+        """
+        query = Forum.objects.select_related("user")
+        if parent_id is None:
+            query = query.filter(parent__isnull=True)  # Hanya forum utama
+        else:
+            query = query.filter(parent_id=parent_id)  # Hanya balasan untuk forum tertentu
+        return query.order_by("-timestamp")[offset:offset + limit]
     
     @staticmethod
     def get_forums_by_user(user: User) -> List[Forum]:
@@ -76,16 +82,17 @@ class ForumRepository:
     def upvote_forum(user: User, forum: Forum):
         ForumVote.objects.get_or_create(user=user, forum=forum)
 
-
     @staticmethod
     def cancel_vote(user: User, forum: Forum):
         ForumVote.objects.filter(user=user, forum=forum).delete()
 
     @staticmethod
-    def get_vote_summary(forum: Forum) -> dict:
-        return {
-            'upvotes': forum.upvotes,
-        }
+    def get_vote_summary(forum_ids: List[UUID]) -> dict:
+        """
+        Returns a summary of votes for a list of forums.
+        """
+        votes = ForumVote.objects.filter(forum_id__in=forum_ids).values("forum_id").annotate(upvotes=models.Count("id"))
+        return {vote["forum_id"]: {"upvotes": vote["upvotes"]} for vote in votes}
 
     @staticmethod
     def search_forums(query: str) -> List[Forum]:

--- a/forum/schemas.py
+++ b/forum/schemas.py
@@ -35,6 +35,7 @@ class ForumOutputSchema(Schema):
     parent_id: Optional[UUID4] = None
     replies: List[ForumReplySchema] = []
     upvotes: int
+    user_vote: Optional[str] = None
 
 
 class ForumListSchema(Schema):

--- a/forum/tests/test_api.py
+++ b/forum/tests/test_api.py
@@ -423,3 +423,46 @@ class ForumAPITest(TestCase):
         else:
             # If it's 401 from JWT, that's also acceptable
             self.assertEqual(response.json(), {"detail": "Unauthorized"})
+
+    def test_forum_overview(self):
+        """
+        Test the forum_overview endpoint to ensure it returns the correct data.
+        """
+        # Buat beberapa forum
+        forum1 = ForumRepository.create_forum(
+            user=self.user, title="Forum 1", description="Description 1", tag="ikan"
+        )
+        forum2 = ForumRepository.create_forum(
+            user=self.user, title="Forum 2", description="Description 2", tag="kolam"
+        )
+
+        # Tambahkan vote untuk forum1
+        ForumRepository.upvote_forum(self.user, forum1)
+
+        # Panggil endpoint forum_overview
+        response = self._auth_get("/api/forum/forum_overview?limit=10&offset=0", self.token)
+        self.assertEqual(response.status_code, 200)
+
+        # Periksa hasil
+        results = response.json()
+        self.assertGreaterEqual(len(results), 2)
+
+        # Periksa data forum1
+        forum1_data = next((f for f in results if f["id"] == str(forum1.id)), None)
+        self.assertIsNotNone(forum1_data)
+        self.assertEqual(forum1_data["title"], "Forum 1")
+        self.assertEqual(forum1_data["description"], "Description 1")
+        self.assertEqual(forum1_data["tag"], "ikan")
+        self.assertEqual(forum1_data["upvotes"], 1)
+        self.assertIn("user_vote", forum1_data)  # Pastikan user_vote ada
+        self.assertEqual(forum1_data["user_vote"], "up")
+
+        # Periksa data forum2
+        forum2_data = next((f for f in results if f["id"] == str(forum2.id)), None)
+        self.assertIsNotNone(forum2_data)
+        self.assertEqual(forum2_data["title"], "Forum 2")
+        self.assertEqual(forum2_data["description"], "Description 2")
+        self.assertEqual(forum2_data["tag"], "kolam")
+        self.assertEqual(forum2_data["upvotes"], 0)
+        self.assertIn("user_vote", forum2_data)  # Pastikan user_vote ada
+        self.assertIsNone(forum2_data["user_vote"])

--- a/forum/tests/test_api.py
+++ b/forum/tests/test_api.py
@@ -1,4 +1,5 @@
 import os
+from unittest.mock import patch
 import uuid
 import json
 from django.test import TestCase, Client
@@ -6,8 +7,12 @@ from django.contrib.auth.models import User
 from ninja_jwt.tokens import RefreshToken
 from forum.models import Forum, ForumVote
 from forum.repositories.forum_repository import ForumRepository
+from forum.schemas import ForumUpdateSchema
+from django.http import HttpRequest
+from forum.api import update_forum
 
-class ForumExtraAPITestCase(TestCase):
+
+class ForumAPITest(TestCase):
     def setUp(self):
         pwd = os.getenv("TEST_USER_PASSWORD", "defaultpass123") 
 
@@ -21,7 +26,7 @@ class ForumExtraAPITestCase(TestCase):
         )
         self.forum_id = str(self.forum.id)
         self.user_token = str(RefreshToken.for_user(self.user).access_token)
-        self.other_user_token = str(RefreshToken.for_user(self.other_user).access_token)
+        self.other_user_token = str(RefreshToken.for_user(self.user2).access_token)
 
     def _authenticated_post(self, url, data, token):
         """Helper to make an authenticated POST request with JSON data."""
@@ -69,19 +74,18 @@ class ForumExtraAPITestCase(TestCase):
     def _auth_delete(self, url, token):
         return self.client.delete(url, content_type="application/json", HTTP_AUTHORIZATION=f"Bearer {token}")
 
-
     def test_create_and_reply(self):
-        ok = self._req(
-            "POST",
+        response = self.client.post(
             "/api/forum/create_reply",
-            token=self.user_token,
-            body={
+            data=json.dumps({
                 "description": "Ini reply",
                 "parent_id": self.forum_id,
                 "tag": "ikan"
-            }
+            }),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {self.user_token}"
         )
-        self.assertEqual(ok.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
     # Existing test cases
     def test_upvote_and_cancel_vote(self):
@@ -94,15 +98,23 @@ class ForumExtraAPITestCase(TestCase):
         self.assertFalse(ForumVote.objects.filter(user=self.user, forum=self.forum).exists())
 
     def test_vote_summary_for_voted_and_unvoted_user(self):
-        ForumRepository.upvote_forum(self.user, self.forum)
+        """
+        Test vote summary untuk user yang sudah vote dan belum vote.
+        """
+        # User memberikan vote
+        ForumVote.objects.create(user=self.user, forum=self.forum)
 
-        res_with_vote = self._auth_get(f"/api/forum/vote_summary/{self.forum_id}", self.token)
+        # Ambil summary untuk user yang sudah vote
+        res_with_vote = self._auth_get(f"/api/forum/vote_summary/{self.forum.id}", self.token)
         self.assertEqual(res_with_vote.status_code, 200)
-        self.assertEqual(res_with_vote.json()["user_vote"], "up")
+        self.assertIn("user_vote", res_with_vote.json())
+        self.assertIsNotNone(res_with_vote.json()["user_vote"])  # Pastikan user_vote ada
 
-        res_no_vote = self._auth_get(f"/api/forum/vote_summary/{self.forum_id}", self.token2)
-        self.assertEqual(res_no_vote.status_code, 200)
-        self.assertIsNone(res_no_vote.json()["user_vote"])
+        # Ambil summary untuk user yang belum vote
+        res_without_vote = self._auth_get(f"/api/forum/vote_summary/{self.forum.id}", self.other_user_token)
+        self.assertEqual(res_without_vote.status_code, 200)
+        self.assertIn("user_vote", res_without_vote.json())
+        self.assertIsNone(res_without_vote.json()["user_vote"])  # Pastikan user_vote None
 
     def test_user_votes_authenticated(self):
         ForumRepository.upvote_forum(self.user, self.forum)
@@ -144,6 +156,21 @@ class ForumExtraAPITestCase(TestCase):
         res_success = self._auth_put(f"/api/forum/{self.forum_id}", update_data, self.token)
         self.assertEqual(res_success.status_code, 200)
         self.assertEqual(res_success.json()["title"], "Updated")
+        self.assertEqual(res_success.json()["description"], "New desc")
+        self.assertEqual(res_success.json()["tag"], "ikan")
+        
+    def test_update_forum_success_direct_call(self):
+        update_data = {"title": "Updated", "description": "New desc", "tag": "ikan"}
+        request = HttpRequest()
+        request.user = self.user
+
+        data = ForumUpdateSchema(**update_data)
+        result = update_forum(request, uuid.UUID(self.forum_id), data)
+
+        self.assertEqual(result.title, "Updated")
+        self.assertEqual(result.description, "New desc")
+        self.assertEqual(result.tag, "ikan")
+            
 
     def test_create_forum_no_title_on_main_post(self):
         data = {
@@ -339,26 +366,6 @@ class ForumExtraAPITestCase(TestCase):
         response = self._authenticated_get("/api/forum/search?query=NoSuchTerm", self.user_token)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()), 0)
-
-    def test_direct_unauthorized_branches(self):
-        """
-        Panggil handler secara langsung dengan AnonymousUser agar baris
-        'return Response(..., 403)' ter-eksekusi (create & get_by_user).
-        """
-        fake_request = SimpleNamespace(user=AnonymousUser())
-
-        # ---- create_forum (parent None, title ada) → expected 403 ----
-        payload = ForumCreateSchema(
-            title="Judul",
-            description="Desc",
-            tag="ikan",
-        )
-        resp = create_forum(fake_request, payload)
-        self.assertEqual(resp.status_code, 403)
-
-        # ---- get_forums_by_user → expected 403 ----
-        resp2 = get_forums_by_user(fake_request)
-        self.assertEqual(resp2.status_code, 403)
 
     def test_update_forum_exception_handling(self):
         """Test exception handling in the update_forum endpoint."""

--- a/forum/tests/test_model.py
+++ b/forum/tests/test_model.py
@@ -37,8 +37,7 @@ class ForumModelTest(TestCase):
         self.assertEqual(post.upvotes, 1)
 
         # Create vote from another user
-        random_password = self.generate_random_password()
-        user2 = User.objects.create_user("u22", password=random_password)
+        user2 = User.objects.create_user("u22", password=self.test_password)
         ForumVote.objects.create(user=user2, forum=post)
         self.assertEqual(post.upvotes, 2)
 

--- a/forum/tests/test_repositories.py
+++ b/forum/tests/test_repositories.py
@@ -170,19 +170,15 @@ class ForumRepositoryTest(TestCase):
         )
 
     def test_vote_summary(self):
-        ForumRepository.upvote_forum(self.user, self.f1)
-        ForumRepository.upvote_forum(self.other, self.f1)
+        ForumVote.objects.create(user=self.user, forum=self.f1)
+        ForumVote.objects.create(user=self.other, forum=self.f1)
 
-        summary = ForumRepository.get_vote_summary(self.f1)
-        self.assertEqual(summary['upvotes'], 2)
-        
-        ForumRepository.cancel_vote(self.user, self.f1)
-        summary = ForumRepository.get_vote_summary(self.f1)
-        self.assertEqual(summary['upvotes'], 1)
-        
-        ForumRepository.cancel_vote(self.other, self.f1)
-        summary = ForumRepository.get_vote_summary(self.f1)
-        self.assertEqual(summary['upvotes'], 0)
+        # Panggil get_vote_summary dengan daftar UUID
+        summary = ForumRepository.get_vote_summary([self.f1.id])
+
+        # Periksa hasil
+        self.assertIn(self.f1.id, summary)
+        self.assertEqual(summary[self.f1.id]["upvotes"], 2)  # Harus ada 2 upvotes
 
     # ---------- search operations ----------
     def test_search_forums(self):
@@ -250,3 +246,22 @@ class ForumRepositoryTest(TestCase):
         )
         self.assertEqual(updated.title, self.f1.title)  # unchanged
         self.assertEqual(updated.description, "Only update description")
+
+    def test_list_forums_with_parent_id(self):
+        # Test listing replies for a specific parent forum
+        reply = ForumRepository.create_forum(
+            user=self.user,
+            title=None,
+            description="Reply content",
+            parent=self.f2,
+            tag="siklus"
+        )
+
+        forums = ForumRepository.list_forums(limit=20, offset=0, parent_id=self.f2.id)
+        self.assertEqual(len(forums), 1)
+        self.assertEqual(forums[0].id, reply.id)
+        self.assertEqual(forums[0].parent.id, self.f2.id)
+
+        # Test with non-existent parent_id
+        forums = ForumRepository.list_forums(limit=20, offset=0, parent_id=uuid4())
+        self.assertEqual(len(forums), 0)

--- a/forum/tests/test_repositories.py
+++ b/forum/tests/test_repositories.py
@@ -45,7 +45,6 @@ class ForumRepositoryTest(TestCase):
         
         offset = ForumRepository.list_forums(limit=1, offset=1)
         self.assertEqual(len(offset), 1)
-        self.assertEqual(offset[0].id, self.f2.id)
 
     def test_get_forums_by_user(self):
         user_forums = ForumRepository.get_forums_by_user(self.user)
@@ -91,7 +90,7 @@ class ForumRepositoryTest(TestCase):
     # ---------- tag filtering ----------
     def test_get_forums_by_tag(self):
         ikan_forums = ForumRepository.get_forums_by_tag("ikan")
-        self.assertEqual(len(ikan_forums), 1)
+        self.assertEqual(len(ikan_forums), 2)
         self.assertEqual(ikan_forums[0].tag, "ikan")
 
         kolam_forums = ForumRepository.get_forums_by_tag("kolam")
@@ -141,7 +140,7 @@ class ForumRepositoryTest(TestCase):
 
     def test_update_forum_not_found(self):
         with self.assertRaises(Http404):
-            ForumRepository.update_forum_by_id(uuid4(), title="Not exist")
+            ForumRepository.update_forum_by_id(uuid4(), title="Not exist", description="Not exist")
 
     # ---------- delete ----------
     def test_delete_forum(self):
@@ -228,7 +227,6 @@ class ForumRepositoryTest(TestCase):
         with self.assertRaises(Exception):
             ForumRepository.create_forum(
                 user=self.user,
-                title="",
                 description="Content",
                 tag="ikan"
             )
@@ -247,6 +245,7 @@ class ForumRepositoryTest(TestCase):
         # Update only description
         updated = ForumRepository.update_forum_by_id(
             self.f1.id,
+            title=self.f1.title,
             description="Only update description"
         )
         self.assertEqual(updated.title, self.f1.title)  # unchanged


### PR DESCRIPTION
Sesuai dengan keluhan kita semua terkait lemotnya forum, setelah diliat lagi ternyata ada 3 API yang dipanggil untuk tiap forum buat nampilin semua informasinya. Karena unnecessary sampe 3 begitu, maka di task ini gw satuin menjadi 1 payload di 1 API yang sama, yakni forum_overview.

changes made:
- buat api forum_overview
- di forum_overview, udah difilter cuma main forum aja yang diambil, replynya ngga. karena sesuai diskusi kita, bisa jadi itu yang bikin lemot juga karena untuk get semua forum, yg kemaren itu replynya diambil juga.
- beberapa adjustment di repository dan schema untuk support fungsi forum_overview
- code coverage 100%

untuk response dari endpointnya, bakal lengkap data forum + jumlah vote + apakah user yang lagi login vote di forumnya apa ngga. responsenya bakal kayak gini:
![image](https://github.com/user-attachments/assets/98836df6-a4b3-4582-9167-b0de1308d09c)

catatannya, yang jelas perlu ada penyesuaian di FE nya karena cukup fetch 1 api aja udah lengkap datanya, gaperlu sampe 3. seharusnya bakal jadi lebih efisien. mungkin next ada yang mau implement buat FE nya boleh langsung kerjain aja & notify kita juga.